### PR TITLE
Fix: remove HPPEMIT to resolve package link errors

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -65,13 +65,6 @@ interface
 {$HPPEMIT '#include <objidl.h>'}
 {$HPPEMIT '#include <oleidl.h>'}
 {$HPPEMIT '#include <oleacc.h>'}
-{$ifdef BCB}
-  {$HPPEMIT '#pragma comment(lib, "VirtualTreesCR")'}
-{$else}
-  {$HPPEMIT '#pragma comment(lib, "VirtualTreesDR")'}
-{$endif}
-{$HPPEMIT '#pragma comment(lib, "Shell32")'}
-{$HPPEMIT '#pragma link "VirtualTrees.Accessibility"'}
 
 uses
   Winapi.Windows, Winapi.oleacc, Winapi.Messages, System.SysUtils, Vcl.Graphics,


### PR DESCRIPTION
We had a lot of trouble in the last week, after adding VirtualTrees to different bpl-packages across our code base.
The lines removed in this PR caused the c++ linker to include your binaries in our first package, and mark them for export. This subsequently resulted in link problems in following packages.

As only the lib user can decide if he want's to statically or dynamically link VirtualTrees into a executable or library, the user has to decide how and what he links.

Therefore you shouldn't hardcode linker directives into library source code.

PS: Thank you for this great package!